### PR TITLE
Userの削除機能を実装

### DIFF
--- a/app/assets/javascripts/tasks/edit_task.js
+++ b/app/assets/javascripts/tasks/edit_task.js
@@ -19,7 +19,7 @@ $(function() {
       taskEditTweetContentArea.val(taskTweetContent)
 
       // タスクの表示に'次の'が含まれている場合、繰り返しタスクとみなす
-      if ($(`#js-tweetTiming-${taskId} small`).text().indexOf('次の') !== -1) {
+      if ($(`#js-nextTweetDatetime-${taskId} small`).text().indexOf('次の') !== -1) {
         let wdayText = $(`#js-tweetTiming-${taskId} span`).text();
         if (wdayText.indexOf('日') !== -1) {
           $(`#js-sun-${taskId}`).prop('checked', true);

--- a/app/assets/javascripts/tasks/update_task.js
+++ b/app/assets/javascripts/tasks/update_task.js
@@ -96,7 +96,7 @@ $(function() {
         $(`#js-taskTitle-${taskId}`).text(taskEditTitle);
         $(`#js-tweetContent-${taskId}`).html(taskEditTweetContent.replace(/\r?\n/g, '<br>'));
         $(`#js-repeatTweetTime-${taskId}`).text(data['repeat_tweet_time']);
-        $(`#js-tweetTiming-${taskId} strong`).text(data['tweet_datetime']);
+        $(`#js-nextTweetDatetime-${taskId} strong`).text(data['tweet_datetime']);
         let wdaysHtml = '';
         let wdays = ['日', '月', '火', '水', '木', '金', '土'];
         for (var i = 0; i < data['wdays'].length; i++) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -105,6 +105,10 @@ form select {
 /* --------------------------------
  * others
  * -------------------------------- */
+#icon-img {
+  border-radius: 50%;
+}
+
 .more-info {
   display: none;
 }

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -13,7 +13,8 @@ class OauthsController < ApplicationController
     redirect_to root_path and return if params[:denied].present?
 
     if @user = login_from(provider)
-      redirect_to user_path(@user), :notice => "Logged in from #{provider.titleize}!"
+      flash[:success] = 'ログインしました'
+      redirect_to user_path(@user)
     else
       begin
         @user = create_from(provider)
@@ -21,16 +22,19 @@ class OauthsController < ApplicationController
         @user.save!
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_to user_path, :notice => "Logged in from #{provider.titleize}!"
+        flash[:success] = 'ログインしました'
+        redirect_to user_path
       rescue
-        redirect_to root_path, :alert => "Failed to login from #{provider.titleize}!"
+        flash[:danger] = 'ログインに失敗しました'
+        redirect_to root_path
       end
     end
   end
 
   def destroy
     logout
-    redirect_to(:root, notice: 'Logged out!')
+    flash[:success] = 'ログアウトしました'
+    redirect_to :root
   end
   #example for Rails 4: add private method below and use "auth_params[:provider]" in place of
   #"params[:provider] above.

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -13,7 +13,7 @@ class OauthsController < ApplicationController
     redirect_to root_path and return if params[:denied].present?
 
     if @user = login_from(provider)
-      redirect_to root_path(@user), :notice => "Logged in from #{provider.titleize}!"
+      redirect_to user_path(@user), :notice => "Logged in from #{provider.titleize}!"
     else
       begin
         @user = create_from(provider)
@@ -21,7 +21,7 @@ class OauthsController < ApplicationController
         @user.save!
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
+        redirect_to user_path, :notice => "Logged in from #{provider.titleize}!"
       rescue
         redirect_to root_path, :alert => "Failed to login from #{provider.titleize}!"
       end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -8,9 +8,9 @@ class TasksController < ApplicationController
     @task.set_next_tweet_date(Time.current)
     respond_to do |format|
       if @task.save
-        format.js { flash[:success] = 'タスクを作成しました！' }
+        format.js { flash.now[:success] = 'タスクを作成しました！' }
       else
-        format.js { flash[:danger] = 'タスクを作成できませんでした' }
+        format.js { flash.now[:danger] = 'タスクを作成できませんでした' }
       end
     end
   end
@@ -39,7 +39,7 @@ class TasksController < ApplicationController
     @task = current_user.tasks.find(params[:id])
     respond_to do |format|
       @task.destroy!
-      format.js { flash[:success] = 'タスクを削除しました' }
+      format.js { flash.now[:success] = 'タスクを削除しました' }
     end
   end
 
@@ -48,9 +48,9 @@ class TasksController < ApplicationController
     respond_to do |format|
       @task.toggle_pause_flag!
       if @task.pause?
-        format.js { flash[:success] = 'タスクを休止しました！' }
+        format.js { flash.now[:success] = 'タスクを休止しました！' }
       elsif @task.active?
-        format.js { flash[:success] = 'タスクを再開しました！' }
+        format.js { flash.now[:success] = 'タスクを再開しました！' }
       end
     end
   end
@@ -59,7 +59,7 @@ class TasksController < ApplicationController
     @task = current_user.tasks.find(params[:id])
     respond_to do |format|
       @task.done!
-      format.js { flash[:success] = 'タスクを完了しました！' }
+      format.js { flash.now[:success] = 'タスクを完了しました！' }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,13 +5,9 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    if current_user.destroy!
-      flash[:success] = 'アカウントを削除しました'
-      redirect_to :root
-    else
-      flash[:danger] = 'アカウントを削除できませんでした'
-      render :show
-    end
+    current_user.destroy!
+    flash[:success] = 'アカウントを削除しました'
+    redirect_to :root
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,4 +3,15 @@ class UsersController < ApplicationController
   def show
     @tasks = current_user.tasks
   end
+
+  def destroy
+    if current_user.destroy!
+      flash[:success] = 'アカウントを削除しました'
+      redirect_to :root
+    else
+      flash[:danger] = 'アカウントを削除できませんでした'
+      render :show
+    end
+  end
+
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,7 +11,8 @@ html
   body
     #nav
       - if current_user
-        = link_to "Logout", :logout, method: :post
+        = link_to "ログアウト", :logout, method: :post, class:'mr-5'
+        = link_to "アカウントを削除", user_path, method: :delete, data: { confirm: 'アカウントを削除しますか？' }
       -  else
         = link_to 'Login with Twitter', auth_at_provider_path(provider: :twitter)
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html
         = link_to "ログアウト", :logout, method: :post, class:'mr-5'
         = link_to "アカウントを削除", user_path, method: :delete, data: { confirm: 'アカウントを削除しますか？' }
       -  else
-        = link_to 'Login with Twitter', auth_at_provider_path(provider: :twitter)
+        = link_to 'Twitterでログイン', auth_at_provider_path(provider: :twitter)
 
     .container
       #js-flash-message style="height: 50px"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,7 +1,7 @@
 .user-profile
+  img id='icon-img' class='mr-2' src="#{current_user.icon_img_url}" style='display:inline-block; height:48px; vertical-align: middle'
   p style='display:inline-block'
     = current_user.name
-  img src="#{current_user.icon_img_url}" style='display:inline-block; height:48px; vertical-align: middle'
 
 .row
   .top-fixed-flash-message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get 'oauth/:provider', as: :auth_at_provider, to: 'oauths#oauth'
   post 'logout', as: :logout, to: 'oauths#destroy'
 
-  resource :user, only: %i[show] do
+  resource :user, only: %i[show destroy] do
     resources :tasks do
       member do
         patch :pause


### PR DESCRIPTION
Close #12 #29 
![destroy_user mov](https://user-images.githubusercontent.com/40616246/73535259-7e079300-4466-11ea-9740-508f299ab3af.gif)
## 概要
- アカウントの削除機能を実装
- Task編集直後に、ツイート時間が更新されないバグを修正
- ユーザーアイコンを丸くする

## コメント
アカウント削除以外に、細かい点を修正しました。（本来はブランチを分けるべきかも）
